### PR TITLE
fix: 修复enterIPPressed方法位置；更改输入长度限制以能完整输入IPv6地址 (fix #1)

### DIFF
--- a/IPv6/Patch/MyPatch.Patching.cs
+++ b/IPv6/Patch/MyPatch.Patching.cs
@@ -57,7 +57,7 @@ namespace IPv6.Patch
 
             foreach (var m in new MethodBase[] {
            AccessTools.Method(typeof(StardewValley.Game1), "UpdateTitleScreen"),
-           AccessTools.Method(typeof(StardewValley.Menus.CoopMenu), "enterIPPressed"),
+           AccessTools.Method(typeof(StardewValley.Menus.CoopGameMenu), "enterIPPressed"),
            AccessTools.Method(typeof(StardewValley.Multiplayer), "LogDisconnect")})
             {
                 Harmony.Patch(m, transpiler: ClientTranspiler);

--- a/IPv6/Patch/MyPatch.Patching.cs
+++ b/IPv6/Patch/MyPatch.Patching.cs
@@ -48,7 +48,11 @@ namespace IPv6.Patch
                 Harmony.Patch(m, transpiler: transpiler);
             }
         }
-
+        
+        private static void TitleTextInputMenu_Postfix(StardewValley.Menus.TitleTextInputMenu __instance, string title, StardewValley.Menus.NamingMenu.doneNamingBehavior b, string default_text, string context, bool filterInput)
+        {
+            __instance.textBox.textLimit = 100;
+        }
 
         public static void Patching(IModHelper helper, string harmonyID)
         {
@@ -62,6 +66,11 @@ namespace IPv6.Patch
             {
                 Harmony.Patch(m, transpiler: ClientTranspiler);
             }
+            
+            var original = AccessTools.Constructor(typeof(StardewValley.Menus.TitleTextInputMenu), new Type[] { typeof(string), typeof(StardewValley.Menus.NamingMenu.doneNamingBehavior), typeof(string), typeof(string), typeof(bool) });
+            var postfix = typeof(MyPatch).GetMethod(nameof(TitleTextInputMenu_Postfix), BindingFlags.Static | BindingFlags.NonPublic);
+            harmony.Patch(original, postfix: new HarmonyMethod(postfix));
+
 
             Harmony.Patch(AccessTools.Constructor(typeof(StardewValley.Network.GameServer), new Type[] { typeof(bool) }), transpiler: ServerTranspiler);
 


### PR DESCRIPTION
This pull request includes changes to the `IPv6/Patch/MyPatch.Patching.cs` file to add a new postfix method and update existing method references. The most important changes include adding a postfix method to set a text limit and updating method references for patching.

New postfix method:

* Added `TitleTextInputMenu_Postfix` method to set the text limit of the `textBox` to 100 characters in the `TitleTextInputMenu` class.

Updated method references:

* Updated the method reference from `StardewValley.Menus.CoopMenu` to `StardewValley.Menus.CoopGameMenu` in the `Patching` method.
* Added patching for the constructor of `StardewValley.Menus.TitleTextInputMenu` with the new postfix method `TitleTextInputMenu_Postfix`.